### PR TITLE
some windows fixes and changed update intervall

### DIFF
--- a/adbb/animeobjs.py
+++ b/adbb/animeobjs.py
@@ -110,7 +110,7 @@ class AniDBObj(object):
     def _db_commit(self, session):
         try:
             session.commit()
-            adbb._log.debug("Object saved to database: {}".format(self.db_data))
+            adbb.log.debug("Object saved to database: {}".format(self.db_data))
         except sqlalchemy.exc.DBAPIError as e:
             if self.db_data:
                 adbb.log.warning("Failed to update data {}: {}".format(
@@ -181,7 +181,7 @@ class Anime(AniDBObj):
         new = None
         if res.rescode == "330":
             self._illegal_object = True
-            self._log.warning('{} is not a valid Anime object'.format(self))
+            self.log.warning('{} is not a valid Anime object'.format(self))
             self._updated.set()
             return
 
@@ -747,7 +747,7 @@ class File(AniDBObj):
             new = FileTable(**finfo)
             new.updated = datetime.datetime.now()
             sess.add(new)
-            adbb._log.debug("Adding mylist info: {}".format(finfo))
+            adbb.log.debug("Adding mylist info: {}".format(finfo))
 
         if new:
             self.db_data = new


### PR DESCRIPTION
Hi,

i changed the update interval to 36 hours, just to-be on the safe side. The remote size check seems pointless, since the anidb guys noted that the file will be updated every 24-48 hours anyway, so size may change always. The request to check the size would also count against the access limit, so if we want to add this logic we need to make sure the check/read happens using the same request.

If possible could you add a extra safeguard using the db itself and store the last url access time, its rather annoying if something goes wrong or the user actually cleaned the temp dirs within 24 hours and you get ip banned for 24 hours. So we should store the last access time in the db and first check this and than the filedate. So that only if the db was deleted and the temp dir cleaned, you might get temp banned.